### PR TITLE
Fix casing of file names in includes

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "Settings.h"
 #include "SplashscreenState.h"
-#include "TitleScreenState.h"
+#include "TitlescreenState.h"
 #include "GameplayState.h"
 #include "CreditsState.h"
 #include "StatsState.h"

--- a/SplashscreenState.cpp
+++ b/SplashscreenState.cpp
@@ -1,4 +1,4 @@
-#include "SplashScreenState.h"
+#include "SplashscreenState.h"
 
 /*
 Copyright (C) 2018 Pharap (@Pharap)

--- a/TitlescreenState.cpp
+++ b/TitlescreenState.cpp
@@ -1,4 +1,4 @@
-#include "TitleScreenState.h"
+#include "TitlescreenState.h"
 
 /*
 Copyright (C) 2018 Pharap (@Pharap)


### PR DESCRIPTION
This should hopefully allow the source to compile on linux.
(Original issue suggested by @uXeBoy.)

Closes #3.