### PR TITLE
Fix offscreen message

### DIFF
--- a/StatsState.cpp
+++ b/StatsState.cpp
@@ -87,8 +87,6 @@ void StatsState::render(StateMachine & machine)
 		arduboy.print(this->stats.wins);
 		
 		y += step;
-
-		y += step;
 		arduboy.setCursor(x, y);
 		arduboy.print(AsFlashString(Strings::Losses));
 		arduboy.print(AsFlashString(Strings::ColonSpace));


### PR DESCRIPTION
The "Deleted" message was offscreen because of the previous commit.
This remedies the situation.