### PR TITLE
Fix type conversion warning

### DIFF
--- a/Minesweeper/Utils/Eeprom.h
+++ b/Minesweeper/Utils/Eeprom.h
@@ -221,7 +221,7 @@ namespace Eeprom
 	template< typename T >
 	void read(uintptr_t address, T array[], size_t quantity)
 	{
-		eeprom_read_block(&array[0], address, sizeof(T) * quantity);
+		eeprom_read_block(&array[0], reinterpret_cast<const void *>(address), sizeof(T) * quantity);
 	}
 
 	template< typename T >


### PR DESCRIPTION
This warning was caused by a small oversight.
Unfortunately this wasn't noticed sooner because of the Arduino IDE's use of the `-fpermissive` compiler flag.