### PR TITLE
Remove dynamic allocation

### DIFF
--- a/Minesweeper/Game.cpp
+++ b/Minesweeper/Game.cpp
@@ -66,7 +66,8 @@ void Game::loop(void)
 
 		if (this->currentStateId != this->nextStateId)
 		{
-			delete this->currentState;
+			// Strictly speaking this does nothing, but I'm keeping it for the sake of correctness
+			this->currentState->~GameState();
 			this->currentState = this->createState(this->nextStateId);
 			this->currentStateId = this->nextStateId;
 		}
@@ -96,14 +97,14 @@ Game::State * Game::createState(const StateId & stateType)
 {
 	switch (stateType)
 	{
-		case GameStateType::SplashScreen: return new SplashScreenState();
-		case GameStateType::TitleScreen: return new TitleScreenState();
-		case GameStateType::Gameplay: return new GameplayState();
-		case GameStateType::Credits: return new CreditsState();
-		case GameStateType::Stats: return new StatsState();
-		case GameStateType::Themes: return new ThemesState();
+		case GameStateType::SplashScreen: return new (&this->stateData[0]) SplashScreenState();
+		case GameStateType::TitleScreen: return new (&this->stateData[0]) TitleScreenState();
+		case GameStateType::Gameplay: return new (&this->stateData[0]) GameplayState();
+		case GameStateType::Credits: return new (&this->stateData[0]) CreditsState();
+		case GameStateType::Stats: return new (&this->stateData[0]) StatsState();
+		case GameStateType::Themes: return new (&this->stateData[0]) ThemesState();
 		#if !DISABLE_SAVE_CHECK
-		case GameStateType::SaveCheck: return new SaveCheckState();
+		case GameStateType::SaveCheck: return new (&this->stateData[0]) SaveCheckState();
 		#endif
 		default: return nullptr;
 	}

--- a/Minesweeper/Game.h
+++ b/Minesweeper/Game.h
@@ -21,14 +21,42 @@
 #include "GameState.h"
 #include "GameStateMachine.h"
 
+#include "Utils.h"
+
+#include "SplashscreenState.h"
+#include "TitlescreenState.h"
+#include "GameplayState.h"
+#include "CreditsState.h"
+#include "StatsState.h"
+#include "ThemesState.h"
+#if !DISABLE_SAVE_CHECK
+#include "SaveCheckState.h"
+#endif
+
 class Game : public GameStateMachine<GameContext, GameStateType>
 {
 private:
+	// This union would be ill formed if it was instantiated
+	union StateData
+	{
+		SplashScreenState splashScreenState;
+		TitleScreenState titleScreenState;
+		GameplayState gameplayState;
+		CreditsState creditsState;
+		StatsState statsState;
+		ThemesState themesState;
+		#if !DISABLE_SAVE_CHECK
+		SaveCheckState saveCheckState;
+		#endif
+	};
+
+private:
 	Context context;
-	State * currentState;
 	StateId currentStateId;
 	StateId nextStateId;
 	bool changePending;
+	State * currentState;
+	char stateData[sizeof(StateData)];
 	
 public:
 	void setup(void);
@@ -40,6 +68,6 @@ public:
 	void changeState(const StateId & stateId) override;
 
 private:
-	static State * createState(const StateId & stateType);
+	State * createState(const StateId & stateType);
 
 };


### PR DESCRIPTION
This replaces the dynamic allocation used by `Game` with a fixed size buffer large enough to hold any of the different `GameState` implementations.
The types are constructed in-place in the buffer using [placement new](https://en.cppreference.com/w/cpp/language/new#Placement_new) (see also #45).