### PR TITLE
Replace C-style cast with static cast

### DIFF
--- a/Minesweeper/GameState.h
+++ b/Minesweeper/GameState.h
@@ -32,12 +32,12 @@ public:
 	virtual void activate(StateMachine & machine)
 	{
 		// Get rid of 'unused parameter' warnings
-		(void)machine;
+		static_cast<void>(machine);
 	}
 	virtual void deactivate(StateMachine & machine)
 	{
 		// Get rid of 'unused parameter' warnings
-		(void)machine;
+		static_cast<void>(machine);
 	}
 	
 	virtual void update(StateMachine & machine) = 0;

--- a/Minesweeper/Utils/AvailableStack.h
+++ b/Minesweeper/Utils/AvailableStack.h
@@ -33,7 +33,7 @@ inline ptrdiff_t getAvailableStackSpace(void)
 	extern int * __brkval; 
 	
 	const int stackTop = 0;
-	(void)stackTop;
+	static_cast<void>(stackTop);
 	
 	return static_cast<ptrdiff_t>(&stackTop - ((__brkval == 0) ? &__heap_start : __brkval));
 }

--- a/Minesweeper/Utils/PlacementNew.h
+++ b/Minesweeper/Utils/PlacementNew.h
@@ -28,6 +28,6 @@
 
 inline void * operator new (size_t size, void * pointer)
 {
-	(void)size;
+	static_cast<void>(size);
 	return pointer;
 }


### PR DESCRIPTION
Replaces C-style casts to `void` with `static_cast`s to `void`.