### PR TITLE
Replace explicit void with empty parameter list

### DIFF
--- a/Minesweeper/ConfirmationMenu.h
+++ b/Minesweeper/ConfirmationMenu.h
@@ -37,7 +37,7 @@ private:
 	uint8_t optionIndex = 1;
 
 public:
-	ConfirmationMenu(void) = default;
+	ConfirmationMenu() = default;
 
 	ConfirmationOption update(Arduboy2 & arduboy)
 	{

--- a/Minesweeper/CreditsState.h
+++ b/Minesweeper/CreditsState.h
@@ -35,7 +35,7 @@ private:
 		char const * const * Entries;
 		uint8_t EntryCount;
 
-		Category(void) = default;
+		Category() = default;
 
 		template< size_t Size >
 		constexpr Category(char const title[], char const * const (&entries)[Size])

--- a/Minesweeper/Game.cpp
+++ b/Minesweeper/Game.cpp
@@ -27,7 +27,7 @@
 #include "SaveCheckState.h"
 #endif
 
-void Game::setup(void)
+void Game::setup()
 {
 	auto & arduboy = this->context.arduboy;
 
@@ -41,7 +41,7 @@ void Game::setup(void)
 	this->currentState->activate(*this);
 }
 
-void Game::loop(void)
+void Game::loop()
 {
 	auto & arduboy = this->context.arduboy;
 
@@ -77,12 +77,12 @@ void Game::loop(void)
 	}
 }
 
-Game::Context & Game::getContext(void)
+Game::Context & Game::getContext()
 {
 	return this->context;
 }
 
-const Game::Context & Game::getContext(void) const
+const Game::Context & Game::getContext() const
 {
 	return this->context;
 }

--- a/Minesweeper/Game.h
+++ b/Minesweeper/Game.h
@@ -59,11 +59,11 @@ private:
 	char stateData[sizeof(StateData)];
 	
 public:
-	void setup(void);
-	void loop(void);
+	void setup();
+	void loop();
 
-	Context & getContext(void) override;
-	const Context & getContext(void) const override;
+	Context & getContext() override;
+	const Context & getContext() const override;
 
 	void changeState(const StateId & stateId) override;
 

--- a/Minesweeper/GameState.h
+++ b/Minesweeper/GameState.h
@@ -27,7 +27,7 @@ public:
 	using StateMachine = GameStateMachine<Context, StateId>;
 
 public:
-	virtual ~GameState(void) {};
+	virtual ~GameState() {};
 
 	virtual void activate(StateMachine & machine)
 	{

--- a/Minesweeper/GameStateMachine.h
+++ b/Minesweeper/GameStateMachine.h
@@ -28,10 +28,10 @@ public:
 	using State = GameState<Context, StateId>;
 
 public:
-	virtual ~GameStateMachine(void) {}
+	virtual ~GameStateMachine() {}
 
-	virtual Context & getContext(void) = 0;
-	virtual const Context & getContext(void) const = 0;
+	virtual Context & getContext() = 0;
+	virtual const Context & getContext() const = 0;
 
 	virtual void changeState(const StateId & stateId) = 0;
 };

--- a/Minesweeper/Grid.h
+++ b/Minesweeper/Grid.h
@@ -40,9 +40,9 @@ private:
 	}
 	
 public:	
-	constexpr uint16_t getCount(void) const;
-	constexpr uint8_t getWidth(void) const;
-	constexpr uint8_t getHeight(void) const;
+	constexpr uint16_t getCount() const;
+	constexpr uint8_t getWidth() const;
+	constexpr uint8_t getHeight() const;
 
 	T & getItem(const uint8_t & x, const uint8_t & y);
 	const T & getItem(const uint8_t & x, const uint8_t & y) const;
@@ -51,19 +51,19 @@ public:
 };
 
 template< typename T, uint8_t Width, uint8_t Height >
-constexpr uint16_t Grid<T, Width, Height>::getCount(void) const
+constexpr uint16_t Grid<T, Width, Height>::getCount() const
 {
 	return Grid<T, Width, Height>::Count;
 }
 	
 template< typename T, uint8_t Width, uint8_t Height >
-constexpr uint8_t Grid<T, Width, Height>::getWidth(void) const
+constexpr uint8_t Grid<T, Width, Height>::getWidth() const
 {
 	return Grid<T, Width, Height>::Width;
 }
 	
 template< typename T, uint8_t Width, uint8_t Height >
-constexpr uint8_t Grid<T, Width, Height>::getHeight(void) const
+constexpr uint8_t Grid<T, Width, Height>::getHeight() const
 {
 	return Grid<T, Width, Height>::Height;
 }

--- a/Minesweeper/Point2.h
+++ b/Minesweeper/Point2.h
@@ -24,7 +24,7 @@ public:
 	T Y;
 
 public:
-	Point2(void);
+	Point2();
 	Point2(const T & x, const T & y);
 };
 
@@ -46,7 +46,7 @@ bool operator !=(const Point2<T> & left, const Point2<T> & right)
 
 
 template< typename T >
-Point2<T>::Point2(void)
+Point2<T>::Point2()
 	: X(), Y()
 {
 }

--- a/Minesweeper/SaveSystem.h
+++ b/Minesweeper/SaveSystem.h
@@ -25,7 +25,7 @@ template< typename TChecksum, size_t EeepromCapacityValue, size_t SaveStartValue
 class SaveSystem
 {
 public:
-	SaveSystem(void) = delete;
+	SaveSystem() = delete;
 
 public:
 	using ChecksumType = TChecksum;
@@ -86,7 +86,7 @@ public:
 	}
 
 	// Calculate the checksum from the data in EEPROM
-	static uint32_t calculateChecksum(void)
+	static uint32_t calculateChecksum()
 	{
 		const size_t dataSize = static_cast<size_t>(Eeprom::read(DataSizeAddress));
 		
@@ -101,7 +101,7 @@ public:
 	}
 
 	// Verify the file checksum
-	static bool verifyChecksum(void)
+	static bool verifyChecksum()
 	{
 		// Used by checksum and savedChecksum
 		constexpr size_t usedSpace = sizeof(uint32_t) * 2;
@@ -122,7 +122,7 @@ public:
 	}
 
 	// Load the data
-	static DataType loadData(void)
+	static DataType loadData()
 	{
 		const uint16_t dataSize = Eeprom::read(DataSizeAddress);
 		const size_t limit = (dataSize < DataSize) ? dataSize : DataSize;

--- a/Minesweeper/Stack.h
+++ b/Minesweeper/Stack.h
@@ -27,50 +27,50 @@ private:
 	uint8_t next;
 	
 public:
-	uint8_t getCapacity(void) const;
-	uint8_t getCount(void) const;
+	uint8_t getCapacity() const;
+	uint8_t getCount() const;
 	
-	bool isEmpty(void) const;
-	bool isFull(void) const;
+	bool isEmpty() const;
+	bool isFull() const;
 	
-	const T & peek(void) const;
-	T && pull(void);
+	const T & peek() const;
+	T && pull();
 	bool push(const T & item);
 };
 
 
 template< typename T, uint8_t Capacity >
-uint8_t Stack<T, Capacity>::getCapacity(void) const
+uint8_t Stack<T, Capacity>::getCapacity() const
 {
 	return capacity;
 }
 
 template< typename T, uint8_t Capacity >
-uint8_t Stack<T, Capacity>::getCount(void) const
+uint8_t Stack<T, Capacity>::getCount() const
 {
 	return this->next;
 }
 
 template< typename T, uint8_t Capacity >
-bool Stack<T, Capacity>::isEmpty(void) const
+bool Stack<T, Capacity>::isEmpty() const
 {
 	return (this->next == 0);
 }
 
 template< typename T, uint8_t Capacity >
-bool Stack<T, Capacity>::isFull(void) const
+bool Stack<T, Capacity>::isFull() const
 {
 	return (this->next == capacity);
 }
 
 template< typename T, uint8_t Capacity >
-const T & Stack<T, Capacity>::peek(void) const
+const T & Stack<T, Capacity>::peek() const
 {
 	return this->items[this->next - 1];
 }
 
 template< typename T, uint8_t Capacity >
-T && Stack<T, Capacity>::pull(void)
+T && Stack<T, Capacity>::pull()
 {
 	--this->next;
 	return static_cast<T&&>(this->items[this->next]);

--- a/Minesweeper/Tile.cpp
+++ b/Minesweeper/Tile.cpp
@@ -16,22 +16,22 @@
 // limitations under the License.
 //
 
-bool Tile::isMine(void) const
+bool Tile::isMine() const
 {
 	return (this->value & isMineMask) != 0;
 }
 
-bool Tile::isVisible(void) const
+bool Tile::isVisible() const
 {
 	return (this->value & isVisibleMask) != 0;
 }
 
-bool Tile::isMarked(void) const
+bool Tile::isMarked() const
 {
 	return (this->value & isMarkedMask) != 0;
 }
 
-uint8_t Tile::getMineCount(void) const
+uint8_t Tile::getMineCount() const
 {
 	return (this->value & MineCountMask);	
 }
@@ -57,27 +57,27 @@ void Tile::setMineCount(const uint8_t & mineCount)
 	this->value |= (mineCount & MineCountMask);
 }
 
-void Tile::show(void)
+void Tile::show()
 {
 	this->value |= isVisibleMask;
 }
 	
-void Tile::hide(void)
+void Tile::hide()
 {
 	this->value &= ~isVisibleMask;
 }
 	
-void Tile::mark(void)
+void Tile::mark()
 {
 	this->value |= isMarkedMask;
 }
 	
-void Tile::unmark(void)
+void Tile::unmark()
 {
 	this->value &= ~isMarkedMask;
 }
 
-void Tile::toggleMark(void)
+void Tile::toggleMark()
 {
 	this->value ^= isMarkedMask;
 }

--- a/Minesweeper/Tile.h
+++ b/Minesweeper/Tile.h
@@ -30,20 +30,20 @@ private:
 	uint8_t value;
 
 public:
-	bool isMine(void) const;
-	bool isVisible(void) const;
-	bool isMarked(void) const;
-	uint8_t getMineCount(void) const;
+	bool isMine() const;
+	bool isVisible() const;
+	bool isMarked() const;
+	uint8_t getMineCount() const;
 	
 	void setIsMine(const bool & isMine);
 	void setIsVisible(const bool & isVisible);
 	void setIsMarked(const bool & isMarked);
 	void setMineCount(const uint8_t & mineCount);
 
-	void show(void);
-	void hide(void);
-	void mark(void);
-	void unmark(void);
+	void show();
+	void hide();
+	void mark();
+	void unmark();
 	
-	void toggleMark(void);
+	void toggleMark();
 };

--- a/Minesweeper/Utils/AvailableStack.h
+++ b/Minesweeper/Utils/AvailableStack.h
@@ -27,7 +27,7 @@
 // and as of this file's creation neither repo has a licence.
 //
 
-inline ptrdiff_t getAvailableStackSpace(void)
+inline ptrdiff_t getAvailableStackSpace()
 {
 	extern int __heap_start;
 	extern int * __brkval; 

--- a/Minesweeper/Utils/ConstUtils.h
+++ b/Minesweeper/Utils/ConstUtils.h
@@ -48,13 +48,13 @@ namespace Details
 }
 
 template< typename T, T ... Ts >
-constexpr T MaxValue(void)
+constexpr T MaxValue()
 {
 	return Details::MaxValueHelper<T, Ts ...>::Value;
 }
 
 template< typename T, T ... Ts >
-constexpr T MinValue(void)
+constexpr T MinValue()
 {
 	return Details::MinValueHelper<T, Ts ...>::Value;
 }

--- a/Minesweeper/Utils/Random.h
+++ b/Minesweeper/Utils/Random.h
@@ -18,7 +18,7 @@
 
 #include <Arduboy2.h>
 
-inline unsigned long generateRandomSeed(void)
+inline unsigned long generateRandomSeed()
 {
 	power_adc_enable(); // ADC on
 


### PR DESCRIPTION
As recommended by the isocpp FAQ question "[Should I use f(void) or f()?](https://isocpp.org/wiki/faq/newbie#void-in-param-list)".

[According to Bjarne Stroustrup](http://www.stroustrup.com/sibling_rivalry.pdf):
> I abandoned the use of void as an argument type meaning "no  arguments" after Dennis Ritchie and Doug McIlroy strongly condemned it as "an  abomination."