### PR TITLE
Remove redundant function overload

### DIFF
--- a/Minesweeper/Utils/ArrayUtils.h
+++ b/Minesweeper/Utils/ArrayUtils.h
@@ -25,11 +25,6 @@ template< typename T, size_t Size > constexpr size_t ArrayLength(T (&)[Size])
 	return Size;
 }
 
-template< typename T > constexpr size_t ArrayLength(T(&)[0])
-{
-	return 0;
-}
-
 //
 // StringLength
 //


### PR DESCRIPTION
Arrays of size zero are illegal in standard C++, so this function is superfluous.

Resolves #64 

